### PR TITLE
Add basic routing for API

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,15 @@
+const express = require('express');
+const appRouter = require('./routes/index')
+
+const path = require('path');
+
+const app = express();
+const port = process.env.PORT || 8080;
+
+app.use(express.static(path.join(__dirname, '../build')));
+
+app.get('/', (_, res) => {
+        res.sendFile(path.join(__dirname, '../build', 'index.html'));
+});
+
+app.listen(port);

--- a/server/index.js
+++ b/server/index.js
@@ -8,6 +8,8 @@ const port = process.env.PORT || 8080;
 
 app.use(express.static(path.join(__dirname, '../build')));
 
+app.use('/', appRouter);
+
 app.get('/', (_, res) => {
         res.sendFile(path.join(__dirname, '../build', 'index.html'));
 });

--- a/server/middleware/profile.js
+++ b/server/middleware/profile.js
@@ -1,0 +1,9 @@
+const GetGithubProfile = (req, res, next) => {
+    return res.status(200).send();
+}
+
+const GetGithubRepos = (req, res, next) => {
+    return res.status(200).send();
+}
+
+module.exports = { GetGithubProfile, GetGithubRepos }; 

--- a/server/middleware/request.js
+++ b/server/middleware/request.js
@@ -1,0 +1,10 @@
+const apiEndpointNotFound = (req, res, next) => {
+    return res.status(404).json(
+        {
+            message: 'Not Found',
+            status: 404
+        }
+    )
+}
+
+module.exports = { apiEndpointNotFound }; 

--- a/server/routes/api/index.js
+++ b/server/routes/api/index.js
@@ -1,0 +1,9 @@
+const router = require('express').Router();
+const { apiEndpointNotFound } = require('../../middleware/request');
+const profileRouter = require('./profile')
+
+router.use('/profile', profileRouter);
+
+router.use(apiEndpointNotFound);
+
+module.exports = router;

--- a/server/routes/api/profile/index.js
+++ b/server/routes/api/profile/index.js
@@ -1,0 +1,8 @@
+const { GetGithubRepos, GetGithubProfile } = require('../../../middleware/profile');
+const router = require('express').Router();
+
+router.get('/info', GetGithubProfile);
+
+router.get('/repos', GetGithubRepos);
+
+module.exports = router;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,0 +1,8 @@
+const { apiEndpointNotFound } = require('../middleware/request');
+const apiRouter = require('./api/index')
+
+const router = require('express').Router();
+
+router.use('/api', apiRouter);
+
+module.exports = router;


### PR DESCRIPTION
This pull request adds the basic express routing for the backend. It contains the following things: 

- The port that express uses can be specified through the environment variable PORT (often used by hosts to specify what port to listen on). If this is not set it defaults to 8080. 
- The build frontend folder is now a static export allowing direct access through the browser.
- The API currently exposes the following endpoints /api/profile/info and /api/profile/repos. If the user tries to navigate to any other endpoint under /api or uses an incorrect verb the api error middleware will return a 404 not found response.